### PR TITLE
Add svgo plugins to the plugin settings

### DIFF
--- a/Svgo.py
+++ b/Svgo.py
@@ -47,7 +47,8 @@ class SvgoMinifyCommand(sublime_plugin.TextCommand):
     def minify(self, data):
         try:
             return node_bridge(data, BIN_PATH, [json.dumps({
-                'indent': get_setting(self.view, 'indent')
+                'indent': get_setting(self.view, 'indent'),
+                'plugins': get_setting(self.view, 'plugins')
             })])
         except Exception as e:
             sublime.error_message('svgo\n%s' % e)
@@ -87,7 +88,8 @@ class SvgoPrettifyCommand(sublime_plugin.TextCommand):
         try:
             return node_bridge(data, BIN_PATH, [json.dumps({
                 'pretty': True,
-                'indent': get_setting(self.view, 'indent')
+                'indent': get_setting(self.view, 'indent'),
+                'plugins': get_setting(self.view, 'plugins')
             })])
         except Exception as e:
             sublime.error_message('svgo\n%s' % e)

--- a/svgo.js
+++ b/svgo.js
@@ -10,17 +10,37 @@ getStdin()
 function minify(data) {
   const options = JSON.parse(process.argv[2]);
   const svg = Buffer.isBuffer(data) ? data.toString() : data;
+  const plugins = [];
+
+  const defaultOptions = {
+    removeTitle: false,
+    removeViewBox: false,
+  };
+
+  // Add user plugins
+  for (let plugin in options.plugins) {
+    plugins.push({
+      // TODO: support old node version?
+      [plugin]: options.plugins[plugin],
+    });
+  }
+
+  // Set default options
+  for (let option in defaultOptions) {
+    if (!plugins.find(plugin => option in plugin)) {
+      plugins.push({
+        // TODO: support old node version?
+        [option]: defaultOptions[option],
+      });
+    }
+  }
 
   const svgo = new SVGO({
     js2svg: {
       pretty: options.pretty,
       indent: options.indent
     },
-    plugins: [{
-      removeTitle: false
-    }, {
-      removeViewBox: false
-    }]
+    plugins: plugins,
   });
 
   return svgo.optimize(svg).then(r => Buffer.from(r.data));


### PR DESCRIPTION
Reason:

I need to remove `width/height/fill...` from the whole svg.

Now you can add `plugins` to user settings

![image](https://user-images.githubusercontent.com/10743009/51065036-cf52a380-1613-11e9-890b-184c73e7c406.png)

```
{
  "plugins": {
    "convertPathData": true,
    "cleanupNumericValues": true,
    "removeDimensions": true
    ...
  }
}
```

Like [here](https://github.com/svg/svgo/blob/master/examples/test.js), but the usual json, which is converted to the desired format 

```
{
  "plugins": {
    "removeTitle": true
  }
}
```

->

```
new SVGO({
  plugins: [
    { removeTitle: true }
  ]
})
```

> **default settings will be overwritten**