### PR TITLE
Stop forcing boolean for plugin options

### DIFF
--- a/svgo.js
+++ b/svgo.js
@@ -20,7 +20,7 @@ function minify(data) {
   // Add user plugins
   for (const plugin of Object.keys(options.plugins || [])) {
     plugins.push({
-      [plugin]: Boolean(options.plugins[plugin]),
+      [plugin]: options.plugins[plugin],
     });
   }
 


### PR DESCRIPTION
Hi! It's me again.

I just got a huge Adobe XD document with a lot of svgs which generates "data-name" attributes. I wanted to clean them up using [the svgo removeAttrs plugin](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) but noticed that you were forcing Boolean for some reason on user plugins.

I don't know what was the reasoning for this Boolean forcing, maybe it was to prevent some kind of other issues with the code, but I'll let you decide if my pull request makes sense.

So far, in my use case, I tested it with and without plugins attribute in Sublime's user configs and by specifying this plugin's options and it works well.

```json
{
  "indent": 2,
  "plugins": {
    "removeAttrs": {
        "attrs": ["^data-name$"]
    }
  }
}
```