### PR TITLE
Fix for svgo 2

### DIFF
--- a/svgo.js
+++ b/svgo.js
@@ -14,30 +14,24 @@ function minify(data) {
 
   const defaultOptions = [
     {
-      name: "removeTitle",
-      active: false
+      "name": "removeTitle",
+      "active": false
     },
     {
-      name: "removeViewBox",
-      active: false
+      "name": "removeViewBox",
+      "active": false
     }
   ];
 
   // Add user plugins
   for (const plugin of Object.keys(options.plugins || [])) {
-    plugins.push({
-      name: options.plugins[plugin].name,
-      params: options.plugins[plugin].params
-    });
+    plugins.push(options.plugins[plugin]);
   }
 
   // Set default options
   for (const option of Object.keys(defaultOptions)) {
     if (!plugins.find(plugin => option in plugin)) {
-      plugins.push({
-        name: defaultOptions[option].name,
-        params: defaultOptions[option].params
-      });
+      plugins.push(defaultOptions[option]);
     }
   }
 

--- a/svgo.js
+++ b/svgo.js
@@ -12,15 +12,22 @@ function minify(data) {
   const svg = Buffer.isBuffer(data) ? data.toString() : data;
   const plugins = [];
 
-  const defaultOptions = {
-    removeTitle: false,
-    removeViewBox: false,
-  };
+  const defaultOptions = [
+    {
+      name: "removeTitle",
+      active: false
+    },
+    {
+      name: "removeViewBox",
+      active: false
+    }
+  ];
 
   // Add user plugins
   for (const plugin of Object.keys(options.plugins || [])) {
     plugins.push({
-      [plugin]: options.plugins[plugin],
+      name: options.plugins[plugin].name,
+      params: options.plugins[plugin].params
     });
   }
 
@@ -28,16 +35,19 @@ function minify(data) {
   for (const option of Object.keys(defaultOptions)) {
     if (!plugins.find(plugin => option in plugin)) {
       plugins.push({
-        [option]: defaultOptions[option],
+        name: defaultOptions[option].name,
+        params: defaultOptions[option].params
       });
     }
   }
 
-  return optimize(svg, {
+  let r = optimize(svg, {
     js2svg: {
       pretty: options.pretty,
       indent: options.indent
     },
     plugins: plugins,
-  }).then(r => Buffer.from(r.data));
+  });
+
+  return Buffer.from(r.data);
 }


### PR DESCRIPTION
Expanded options in svgo2 need a "name" and "params" key if the plugin has options to be passed, so this fixes it, but should also require an update for those of us who have custom plugins enabled in the plugin's config.